### PR TITLE
Fix potentially invalid cameraId in viewState

### DIFF
--- a/app/src/main/java/com/samsung/android/scan3d/serv/CamEngine.kt
+++ b/app/src/main/java/com/samsung/android/scan3d/serv/CamEngine.kt
@@ -86,7 +86,7 @@ class CamEngine(val context: Context) {
     var viewState: CameraFragment.Companion.ViewState = CameraFragment.Companion.ViewState(
         true,
         stream = false,
-        cameraId = "0",
+        cameraId = cameraList.first().cameraId,
         quality = 80,
         resolutionIndex = null
     )


### PR DESCRIPTION
On my Galaxy S23 Ultra with OneUI 5.1 there's no cameraId == "0" and app keeps crashing. This change fixes the issue.

![图片](https://github.com/Ruddle/RemoteCam/assets/49363666/e551a49b-8448-45f8-be47-907f4da0908f)
